### PR TITLE
Add MIT license to i18n WG

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,11 @@
+## i18n Working Group License
+
+The MIT License (MIT)
+
+Copyright (c) 2018 Node.js Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ In order to ensure best practices, this working group may work directly with rep
 
 If you're interested in joining this group, or would like to leave a question or comment for its members - please [create an issue](https://github.com/nodejs/i18n/issues/new) or submit a pull request.
 
+## License
+[MIT](./LICENSE.md)
 
 ----
 _This document was influenced by the [nodejs/Intl](https://github.com/nodejs/Intl/blob/master/README.md) working group's mandate, and is seen as a continuation of that work._


### PR DESCRIPTION
## Purpose
In [today's CommComm meeting](https://github.com/nodejs/community-committee/issues/245), @amiller-gh brought up the important issue: that not providing an MIT license can prevent some people from contributing to our initiative and joining our WG.

## Description
This adds the [MIT license](https://opensource.org/licenses/MIT) to our WG. The same license [currently used by the Community Committee](https://github.com/nodejs/community-committee/blob/master/LICENSE#L3).
