### PR TITLE
add a joining heading to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ In order to ensure best practices, this working group may work directly with rep
 * [Czech (nodejs-cs)](https://github.com/nodejs/nodejs-cs)
 * [Swedish (nodejs-sv)](https://github.com/nodejs/nodejs-sv)
 
-
+## Joining
 If you're interested in joining this group, or would like to leave a question or comment for its members - please [create an issue](https://github.com/nodejs/i18n/issues/new) or submit a pull request.
 
 ----


### PR DESCRIPTION
This PR adds an H2 heading that will make it easier to share a deep link to instructions on how to join this working group, i.e. `https://github.com/nodejs/i18n#joining`