### PR TITLE
download nodejs archive bundle to repo dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 coverage
 node_modules
 *.tgz
+temp
+.idea

--- a/package.json
+++ b/package.json
@@ -20,11 +20,10 @@
   "devDependencies": {
     "download": "^6.2.5",
     "jest": "^22.4.3",
-    "mkdirp": "^0.5.1",
     "semver": "^5.5.0",
     "standard": "^11.0.1",
-    "temp": "^0.8.3",
-    "walk-sync": "^0.3.2"
+    "walk-sync": "^0.3.2",
+    "fs-extra": "^5.0.0"
   },
   "standard": {
     "env": [

--- a/script/collect.js
+++ b/script/collect.js
@@ -10,37 +10,36 @@ collect()
 
 async function collect () {
   for (const version of nodeVersions) {
-    await getDocsForNodeVersion(version)
+    await getDocsForNodeVersion(version).catch(err => {
+      console.error(`problem fetching version: ${version}`)
+      console.error(err)
+    })
   }
 }
 
 async function getDocsForNodeVersion (version) {
-  try {
-    const docDir = path.join(__dirname, `../content/${version}/en-US/doc`)
-    const tempDir = path.join(__dirname, `../temp/${version}`)
+  const docDir = path.join(__dirname, `../content/${version}/en-US/doc`)
+  const tempDir = path.join(__dirname, `../temp/${version}`)
 
-    // exit early if docs for this version have already been downloaded
-    if (fs.existsSync(docDir)) {
-      console.log(`docs for ${version} have already been collected; skipping`)
-      return
-    }
-
-    // download repo bundle and extract to a temporary directory
-    const tarballUrl = `https://github.com/nodejs/node/archive/${version}.tar.gz`
-    console.log('downloading', tarballUrl)
-    await download(tarballUrl, tempDir, {extract: true})
-
-    // move docs from temp dir to this repo
-    const tempDocDir = path.join(tempDir, `node-${version.replace('v', '')}`, 'doc')
-    await fs.move(tempDocDir, docDir)
-
-    // keep .md files and remove all others
-    walk(docDir, {directories: false})
-      .filter(file => path.extname(file.relativePath.toLowerCase()) !== '.md')
-      .forEach(file => fs.unlinkSync(path.join(docDir, file.relativePath)))
-
-    fs.remove(tempDir)
-  } catch (ex) {
-    console.error(`error during getting docs for ${version}: ${ex}`)
+  // exit early if docs for this version have already been downloaded
+  if (fs.existsSync(docDir)) {
+    console.log(`docs for ${version} have already been collected; skipping`)
+    return
   }
+
+  // download repo bundle and extract to a temporary directory
+  const tarballUrl = `https://github.com/nodejs/node/archive/${version}.tar.gz`
+  console.log('downloading', tarballUrl)
+  await download(tarballUrl, tempDir, {extract: true})
+
+  // move docs from temp dir to this repo
+  const tempDocDir = path.join(tempDir, `node-${version.replace('v', '')}`, 'doc')
+  await fs.move(tempDocDir, docDir)
+
+  // keep .md files and remove all others
+  walk(docDir, {directories: false})
+    .filter(file => path.extname(file.relativePath.toLowerCase()) !== '.md')
+    .forEach(file => fs.unlinkSync(path.join(docDir, file.relativePath)))
+
+  fs.remove(tempDir)
 }

--- a/script/collect.js
+++ b/script/collect.js
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
-const fs = require('fs')
+const fs = require('fs-extra')
 const path = require('path')
 const download = require('download')
-const mkdirp = require('mkdirp').sync
-const temp = require('temp')
 const walk = require('walk-sync').entries
 const {nodeVersions} = require('../package.json')
 
@@ -17,27 +15,32 @@ async function collect () {
 }
 
 async function getDocsForNodeVersion (version) {
-  const docDir = path.join(__dirname, `../content/${version}/en-US/doc`)
+  try {
+    const docDir = path.join(__dirname, `../content/${version}/en-US/doc`)
+    const tempDir = path.join(__dirname, `../temp/${version}`)
 
-  // exit early if docs for this version have already been downloaded
-  if (fs.existsSync(docDir)) {
-    console.log(`docs for ${version} have already been collected; skipping`)
-    return
+    // exit early if docs for this version have already been downloaded
+    if (fs.existsSync(docDir)) {
+      console.log(`docs for ${version} have already been collected; skipping`)
+      return
+    }
+
+    // download repo bundle and extract to a temporary directory
+    const tarballUrl = `https://github.com/nodejs/node/archive/${version}.tar.gz`
+    console.log('downloading', tarballUrl)
+    await download(tarballUrl, tempDir, {extract: true})
+
+    // move docs from temp dir to this repo
+    const tempDocDir = path.join(tempDir, `node-${version.replace('v', '')}`, 'doc')
+    await fs.move(tempDocDir, docDir)
+
+    // keep .md files and remove all others
+    walk(docDir, {directories: false})
+      .filter(file => path.extname(file.relativePath.toLowerCase()) !== '.md')
+      .forEach(file => fs.unlinkSync(path.join(docDir, file.relativePath)))
+
+    fs.remove(tempDir)
+  } catch (ex) {
+    console.error(`error during getting docs for ${version}: ${ex}`)
   }
-
-  // download repo bundle and extract to a temporary directory
-  const tarballUrl = `https://github.com/nodejs/node/archive/${version}.tar.gz`
-  console.log('downloading', tarballUrl)
-  const tempDir = temp.mkdirSync()
-  await download(tarballUrl, tempDir, {extract: true})
-
-  // move docs from temp dir to this repo
-  const tempDocDir = path.join(tempDir, `node-${version.replace('v', '')}`, 'doc')
-  mkdirp(docDir)
-  fs.renameSync(tempDocDir, docDir)
-
-  // keep .md files and remove all others
-  walk(docDir, {directories: false})
-    .filter(file => path.extname(file.relativePath.toLowerCase()) !== '.md')
-    .forEach(file => fs.unlinkSync(path.join(docDir, file.relativePath)))
 }

--- a/script/collect.js
+++ b/script/collect.js
@@ -35,11 +35,10 @@ async function getDocsForNodeVersion (version) {
   // move docs from temp dir to this repo
   const tempDocDir = path.join(tempDir, `node-${version.replace('v', '')}`, 'doc')
   await fs.move(tempDocDir, docDir)
+  fs.remove(tempDir)
 
   // keep .md files and remove all others
   walk(docDir, {directories: false})
     .filter(file => path.extname(file.relativePath.toLowerCase()) !== '.md')
     .forEach(file => fs.unlinkSync(path.join(docDir, file.relativePath)))
-
-  fs.remove(tempDir)
 }


### PR DESCRIPTION
Hi, according to discussion in  #55 I prepare this PR where I download node.js archive bundle to the repo dir. I tested this on windows and on linux using docker.

At the the moment tests are passing only after we download bundles, if we try to run those tests before we download bundles the tests will fail - this could be potential problem during integration with Ci to run tests automatically.

Regards,