### PR TITLE
Add Brazilian Portuguese

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Help us get the documentation translated into your native language and reach mor
 - [Norwegian](https://crowdin.com/project/nodejs/no)
 - [Polish](https://crowdin.com/project/nodejs/pl)
 - [Portuguese](https://crowdin.com/project/nodejs/pt-PT)
+- [Portuguese (Brazil)](https://crowdin.com/project/nodejs/pt-BR)
 - [Romanian](https://crowdin.com/project/nodejs/ro)
 - [Russian](https://crowdin.com/project/nodejs/ru)
 - [Slovak](https://crowdin.com/project/nodejs/sk)


### PR DESCRIPTION
As Brazilian Portuguese and Portugal Portuguese are separated in [crowdin](https://crowdin.com/project/nodejs), we could add a link pointing to the correct page in "Languages being translated" section.

[pt-PT] link was already in the document, I just added a new link pointing to [pt-BR]