### PR TITLE
build: Upload Glossary on merge to master

### DIFF
--- a/.github/workflows/glossary.yml
+++ b/.github/workflows/glossary.yml
@@ -1,0 +1,38 @@
+name: Upload Crowdin Glossary
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - "crowdin-glossary.json"
+    - "script/upload-crowdin-glossary.js"
+    - "package.json"
+    - "package-lock.json"
+    - ".github/workflows/glossary.yml"
+
+jobs:
+  glossary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install
+        run: npm ci
+
+      - name: Upload Glossary
+        run: npm run upload-crowdin-glossary
+        env:
+          CROWDIN_KEY: ${{ secrets.CROWDIN_KEY }}


### PR DESCRIPTION
Fixes #231

Not sure about if there is further work to wire in the upload with the CROWDIN_KEY

Someone will also need to set the `CROWDIN_KEY` value in the repo's secrets