### PR TITLE
fix: status script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 temp
 .idea
 yarn.lock
+stats.json

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "jest",
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "status": "script/status.js"
+    "status": "node script/status.js"
   },
   "devDependencies": {
     "builtins": "^3.0.1",

--- a/script/status.js
+++ b/script/status.js
@@ -3,7 +3,7 @@
 const fs = require('fs')
 const path = require('path')
 const request = require('request')
-require('dotenv-safe').load()
+require('dotenv-safe').config()
 
 const projectKey = process.env.CROWDIN_KEY
 
@@ -11,4 +11,4 @@ const url = `https://api.crowdin.com/api/project/nodejs/status?key=${projectKey}
 
 request.post(url)
   .on('error', err => console.error(err))
-  .pipe(fs.createWriteStream(path.join(__dirname, '../stats.json')))
+  .pipe(fs.createWriteStream(path.join(__dirname, '..', 'stats.json')))


### PR DESCRIPTION

- Call script through Node in NPM script
- `load` is no longer a funtion on the current dotenv-safe release
- Ignore the output stats.json file from Git