### PR TITLE
feat: Simplify collect script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 coverage
 node_modules
 *.tgz
-temp
 .idea
 yarn.lock
 stats.json

--- a/script/collect.js
+++ b/script/collect.js
@@ -3,7 +3,6 @@
 const fs = require('fs-extra')
 const path = require('path')
 const download = require('download')
-const walk = require('walk-sync').entries
 const { nodeVersions } = require('../package.json')
 
 collect()
@@ -19,28 +18,18 @@ async function collect () {
 }
 
 async function getDocsForNodeVersion (major, version) {
-  const docDir = path.join(__dirname, `../content/${major}/en-US/doc`)
-  const tempDir = path.join(__dirname, `../temp/${major}`)
-
-  // TODO exit early if docs for this version have already been downloaded
+  const docDir = path.join(__dirname, `../content/${major}/en-US`)
+  const downloadOptions = {
+    extract: true,
+    strip: 1,
+    filter: file => path.extname(file.path) === '.md' && file.path.startsWith('doc')
+  }
 
   // clean out english translations to ensure old files are removed
   fs.remove(docDir)
 
-  // download repo bundle and extract to a temporary directory
+  // download repo bundle and extract
   const tarballUrl = `https://github.com/nodejs/node/archive/${version}.tar.gz`
   console.log('downloading', tarballUrl)
-  await download(tarballUrl, tempDir, { extract: true })
-
-  // move docs from temp dir to this repo
-  const tempDocDir = path.join(tempDir, `node-${version.replace('v', '')}`, 'doc')
-
-  // removes files other than markdown
-  walk(tempDocDir, { directories: false })
-    .filter(file => path.extname(file.relativePath.toLowerCase()) !== '.md')
-    .forEach(file => fs.unlinkSync(path.join(tempDocDir, file.relativePath)))
-
-  await fs.copy(tempDocDir, docDir)
-
-  fs.remove(tempDir)
+  await download(tarballUrl, docDir, downloadOptions)
 }


### PR DESCRIPTION

Removes the use of the temporary download and dirctory.
Uses the `download` package to extract in-place.