### PR TITLE
feat: Updated nightly-sync.yml

### DIFF
--- a/.github/workflows/nightly-sync.yml
+++ b/.github/workflows/nightly-sync.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   sync:
+    if: github.repository == 'nodejs/i18n'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -28,16 +29,10 @@ jobs:
       - name: Collect latest releases
         run: npm run collect
 
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v4
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v2
         with:
-          author_name: GitHub Action
-          author_email: action@github.com
-          message: "feat: Content updates"
-
-      - name: Push changes
-        # Only run this on the main nodejs repo and not forks
-        if: github.repository == 'nodejs/i18n'
-        uses: ad-m/github-push-action@v0.5.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'feat: Original content updates'
+          title: Original content updates
+          body: Auto-generated PR with content updates from [nodejs/node](https://github.com/nodejs/node) repo
+          team-reviewers: nodejs/i18n,nodejs/i18n-api


### PR DESCRIPTION
Our `master` branch protected from direct pushes, and our auto-sync script cannot succeed (https://github.com/nodejs/i18n/runs/581690377?check_suite_focus=true).
Two possible solutions:
- allow _github-actions bot_ to make direct commits to `master`
- go through PR flow

This PR contain changes to nightly-sync.yml, that will implement second way: 
1. Added condition to run this script only in original repo `nodejs/i18n`
2. Replaced "commit" action with "PR creating" action