### PR TITLE
fix: missing runtime dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1048,8 +1048,7 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/prettier": {
       "version": "1.19.1",
@@ -1418,8 +1417,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1505,7 +1503,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1863,8 +1860,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "contains-path": {
       "version": "0.1.0",
@@ -2351,8 +2347,7 @@
     "ensure-posix-path": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
-      "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==",
-      "dev": true
+      "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -5563,12 +5558,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -5645,7 +5634,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
       "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-      "dev": true,
       "requires": {
         "@types/minimatch": "^3.0.3",
         "minimatch": "^3.0.2"
@@ -5710,7 +5698,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -8069,7 +8056,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
       "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
-      "dev": true,
       "requires": {
         "@types/minimatch": "^3.0.3",
         "ensure-posix-path": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "lint": "standard",
     "lint:fix": "standard --fix"
   },
+  "dependencies": {
+    "lodash": "^4.17.15",
+    "walk-sync": "^2.1.0"
+  },
   "devDependencies": {
     "builtins": "^3.0.1",
     "crowdin-glossary": "^1.2.0",
@@ -31,11 +35,9 @@
     "fs-extra": "^9.0.0",
     "globals": "^13.0.0",
     "jest": "^25.3.0",
-    "lodash.difference": "^4.5.0",
     "semver": "^7.3.2",
     "standard": "^14.3.3",
-    "superagent": "^5.2.2",
-    "walk-sync": "^2.1.0"
+    "superagent": "^5.2.2"
   },
   "standard": {
     "env": [
@@ -45,8 +47,5 @@
   "jest": {
     "verbose": true,
     "testURL": "http://localhost"
-  },
-  "dependencies": {
-    "lodash": "^4.17.15"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra')
 const path = require('path')
 const walk = require('walk-sync')
-const difference = require('lodash.difference')
+const { difference } = require('lodash')
 const { supportedVersions } = require('./package.json')
 
 const contentDir = path.join(__dirname, 'content')


### PR DESCRIPTION
I just ran `npm install nodejs/i18n`(see #250 which landed earlier today) and was greeted with this error when I tried to use it:

```
internal/modules/cjs/loader.js:716
    throw err;
    ^

Error: Cannot find module 'walk-sync'
Require stack:
```

This PR moves required runtime dependencies in package.json, and removes lodash since we already have the full lodash as a dep.