### PR TITLE
Tweak GHA config

### DIFF
--- a/.github/workflows/check-i18n-changes.yml
+++ b/.github/workflows/check-i18n-changes.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/setup-node@v2.2.0
         with:
           node-version: "14"
+          cache: "npm"
 
       - name: Fail for non-Crowdin pushes
         if: github.actor != 'nodejs-crowdin' && github.actor != 'github-actions[bot]'

--- a/.github/workflows/check-i18n-changes.yml
+++ b/.github/workflows/check-i18n-changes.yml
@@ -13,9 +13,9 @@ jobs:
 
       - uses: actions/setup-node@v2.2.0
         with:
-          node-version: "12.x"
+          node-version: "14"
 
-      - name:  Fail for non-Crowdin pushes
+      - name: Fail for non-Crowdin pushes
         if: github.actor != 'nodejs-crowdin' && github.actor != 'github-actions[bot]'
         uses: thollander/actions-comment-pull-request@master
         with:

--- a/.github/workflows/glossary.yml
+++ b/.github/workflows/glossary.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v2.2.0
         with:
-          node-version: "12.x"
+          node-version: "14"
 
       - name: Cache node modules
         uses: actions/cache@v2.1.6

--- a/.github/workflows/glossary.yml
+++ b/.github/workflows/glossary.yml
@@ -20,14 +20,7 @@ jobs:
       - uses: actions/setup-node@v2.2.0
         with:
           node-version: "14"
-
-      - name: Cache node modules
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: "npm"
 
       - name: Install
         run: npm ci

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v2.2.0
         with:
-          node-version: "12.x"
+          node-version: "14"
 
       - name: Cache node modules
         uses: actions/cache@v2.1.6

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -17,14 +17,8 @@ jobs:
       - uses: actions/setup-node@v2.2.0
         with:
           node-version: "14"
+          cache: "npm"
 
-      - name: Cache node modules
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
       - name: Install
         run: npm ci
       - name: Lint JavaScript files

--- a/.github/workflows/nightly-sync.yml
+++ b/.github/workflows/nightly-sync.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v2.2.0
         with:
-          node-version: "12.x"
+          node-version: "14"
 
       - name: Cache node modules
         uses: actions/cache@v2.1.6

--- a/.github/workflows/nightly-sync.yml
+++ b/.github/workflows/nightly-sync.yml
@@ -14,14 +14,7 @@ jobs:
       - uses: actions/setup-node@v2.2.0
         with:
           node-version: "14"
-
-      - name: Cache node modules
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: "npm"
 
       - name: Install
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
 
       - uses: actions/setup-node@v2.2.0
         with:
-          node-version: "12.x"
+          node-version: "14"
 
       - name: Cache node modules
         uses: actions/cache@v2.1.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,8 @@ jobs:
       - uses: actions/setup-node@v2.2.0
         with:
           node-version: "14"
+          cache: "npm"
 
-      - name: Cache node modules
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
       - name: Install
         run: npm ci
 


### PR DESCRIPTION
- use Node.js v14 as the active LTS is now v14
- use actions/setup-node's built-in cache feature to shrink our GHA config, see https://github.com/actions/setup-node/releases/tag/v2.2.0 for details