### PR TITLE
CI: Specify the version on actions-comment-pull-request

### DIFF
--- a/.github/workflows/check-i18n-changes.yml
+++ b/.github/workflows/check-i18n-changes.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Fail for non-Crowdin pushes
         if: github.actor != 'nodejs-crowdin' && github.actor != 'github-actions[bot]'
-        uses: thollander/actions-comment-pull-request@master
+        uses: thollander/actions-comment-pull-request@1.0.3
         with:
           message: |
             Thank you for contribution!


### PR DESCRIPTION
They've renamed the branch name to `main`: https://github.com/thollander/actions-comment-pull-request
I think it makes sense to use a version number instead of a branch name as pulling the latest changes isn't important here and dependabot can automatically handle the version bumps.